### PR TITLE
TAVC-1407 Convert subscription data to be sent to backend and handle response

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -30,6 +30,7 @@ trait AppConfig {
   val ggSignInUrl: String
   val introductionUrl: String
   val businessCustomerUrl: String
+  val submissionUrl: String
 }
 
 object FrontendAppConfig extends AppConfig with ServicesConfig {
@@ -50,4 +51,5 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   override lazy val twoFactorUrl = configuration.getString("two-factor.host").getOrElse("")
   override lazy val introductionUrl = configuration.getString("introduction.url").getOrElse("")
   override lazy val businessCustomerUrl = configuration.getString("business-customer.url").getOrElse("")
+  override lazy val submissionUrl = configuration.getString("submission.url").getOrElse("")
 }

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.WSHttp
+import models.etmp.SubscriptionTypeModel
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, HttpResponse}
+
+import scala.concurrent.Future
+
+object SubscriptionConnector extends SubscriptionConnector with ServicesConfig {
+  override val http = WSHttp
+  override val serviceUrl = baseUrl("investment-tax-relief-submission")
+}
+
+trait SubscriptionConnector {
+
+  val http: HttpPost
+  val serviceUrl: String
+
+  def subscribe(subscriptionModel: SubscriptionTypeModel, safeID: String, postcode: String)
+               (implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    http.POST[JsValue, HttpResponse](s"$serviceUrl/investment-tax-relief-subscription/$safeID/$postcode/subscribe",Json.toJson(subscriptionModel))
+  }
+
+}

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 
 object SubscriptionConnector extends SubscriptionConnector with ServicesConfig {
   override val http = WSHttp
-  override val serviceUrl = baseUrl("investment-tax-relief-submission")
+  override val serviceUrl = baseUrl("investment-tax-relief-subscription")
 }
 
 trait SubscriptionConnector {

--- a/app/controllers/ReviewCompanyDetailsController.scala
+++ b/app/controllers/ReviewCompanyDetailsController.scala
@@ -24,6 +24,7 @@ import models.{CompanyRegistrationReviewDetailsModel, ContactDetailsSubscription
 import play.api.mvc.{AnyContent, Request, Result}
 import services.RegisteredBusinessCustomerService
 import uk.gov.hmrc.play.frontend.controller.FrontendController
+import utils.CountriesHelper
 import views.html.registrationInformation.ReviewCompanyDetails
 
 import scala.concurrent.Future
@@ -56,10 +57,13 @@ trait ReviewCompanyDetailsController extends FrontendController with AuthorisedF
                                               correspondenceAddress: Option[ProvideCorrespondAddressModel],
                                               contactDetails: Option[ContactDetailsSubscriptionModel])
                                              (implicit request: Request[AnyContent]): Future[Result] = {
-    if (registrationReviewDetails.isDefined && correspondenceAddress.isDefined && contactDetails.isDefined) {
-      Future.successful(Ok(ReviewCompanyDetails(
-        ReviewCompanyDetailsModel(registrationReviewDetails.get,correspondenceAddress.get,contactDetails.get))))
-    } else Future.successful(Redirect(routes.ConfirmCorrespondAddressController.show()))
+    (registrationReviewDetails, correspondenceAddress, contactDetails) match {
+      case (Some(regDetails), Some(corrAddress), Some(contact)) => {
+        val address = corrAddress.copy(countryCode = CountriesHelper.getSelectedCountry(corrAddress.countryCode))
+        Future.successful(Ok(ReviewCompanyDetails(ReviewCompanyDetailsModel(regDetails, address, contact))))
+      }
+      case (_, _, _) => Future.successful(Redirect(routes.ConfirmCorrespondAddressController.show()))
+    }
   }
 
 }

--- a/app/forms/ContactDetailsSubscriptionForm.scala
+++ b/app/forms/ContactDetailsSubscriptionForm.scala
@@ -26,7 +26,7 @@ object ContactDetailsSubscriptionForm {
       "firstName" -> nonEmptyText,
       "lastName" -> nonEmptyText,
       "telephoneNumber" -> utils.Validation.telephoneNumberCheck,
-      "telephoneNumber2" -> utils.Validation.optionalTelephoneNumberCheck,
+      "telephoneNumber2" -> optional(utils.Validation.optionalTelephoneNumberCheck),
       "email" -> utils.Validation.emailCheck
     )(ContactDetailsSubscriptionModel.apply)(ContactDetailsSubscriptionModel.unapply)
   )

--- a/app/forms/ProvideCorrespondAddressForm.scala
+++ b/app/forms/ProvideCorrespondAddressForm.scala
@@ -25,9 +25,9 @@ object ProvideCorrespondAddressForm {
     mapping(
       "addressline1" -> utils.Validation.mandatoryAddressLineCheck,
       "addressline2" -> utils.Validation.mandatoryAddressLineCheck,
-      "addressline3" -> utils.Validation.optionalAddressLineCheck,
-      "addressline4" -> utils.Validation.addressLineFourCheck,
-      "postcode" -> utils.Validation.optionalPostcodeCheck,
+      "addressline3" -> optional(utils.Validation.optionalAddressLineCheck),
+      "addressline4" -> optional(utils.Validation.addressLineFourCheck),
+      "postcode" -> optional(utils.Validation.optionalPostcodeCheck),
       "countryCode" -> utils.Validation.countryCodeCheck
     )(ProvideCorrespondAddressModel.apply)(ProvideCorrespondAddressModel.unapply)
   )

--- a/app/models/ContactDetailsSubscriptionModel.scala
+++ b/app/models/ContactDetailsSubscriptionModel.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 case class ContactDetailsSubscriptionModel(firstName : String,
                                          lastName : String,
                                          telephoneNumber : String,
-                                         telephoneNumber2 : String,
+                                         telephoneNumber2 : Option[String],
                                          email : String)
 
 object ContactDetailsSubscriptionModel {

--- a/app/models/ProvideCorrespondAddressModel.scala
+++ b/app/models/ProvideCorrespondAddressModel.scala
@@ -20,9 +20,9 @@ import play.api.libs.json.Json
 
 case class ProvideCorrespondAddressModel(addressline1 : String,
                                          addressline2 : String,
-                                         addressline3 : String,
-                                         addressline4 : String,
-                                         postcode : String,
+                                         addressline3 : Option[String],
+                                         addressline4 : Option[String],
+                                         postcode : Option[String],
                                          countryCode : String)
 
 object ProvideCorrespondAddressModel {

--- a/app/models/etmp/SubscriptionTypeModel.scala
+++ b/app/models/etmp/SubscriptionTypeModel.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.etmp
+
+import models.{ContactDetailsSubscriptionModel, ProvideCorrespondAddressModel}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+case class IntermediateCorrespondenceDetailsModel(correspondenceAddress: ProvideCorrespondAddressModel,
+                                                  contactDetails: ContactDetailsSubscriptionModel)
+
+case class IntermediateSubscriptionTypeModel(correspondenceDetails: IntermediateCorrespondenceDetailsModel)
+
+object IntermediateCorrespondenceDetailsModel {
+  implicit val formats = Json.format[IntermediateCorrespondenceDetailsModel]
+}
+
+object IntermediateSubscriptionTypeModel {
+  implicit val formats = Json.format[IntermediateSubscriptionTypeModel]
+}
+
+case class ContactAddressModel (addressLine1 : String,
+                                addressLine2: String,
+                                addressLine3 : Option[String],
+                                addressLine4: Option[String],
+                                countryCode : String,
+                                postalCode: Option[String])
+
+object ContactAddressModel {
+
+  implicit val reads: Reads[ContactAddressModel] = (
+    (__ \"addressline1").read[String] and
+      (__ \"addressline2").read[String] and
+      (__ \"addressline3").readNullable[String] and
+      (__ \"addressline4").readNullable[String] and
+      (__ \"countryCode").read[String] and
+      (__ \"postcode").readNullable[String]
+    )(ContactAddressModel.apply _)
+
+  implicit val writes = Json.writes[ContactAddressModel]
+}
+
+case class ContactDetailsModel (phoneNumber : Option[String],
+                                mobileNumber: Option[String],
+                                faxNumber : Option[String],
+                                emailAddress: Option[String])
+
+object ContactDetailsModel {
+
+  implicit val reads: Reads[ContactDetailsModel] = (
+    (__ \"telephoneNumber").readNullable[String] and
+      (__ \"telephoneNumber2").readNullable[String] and
+      (__ \"faxNumber").readNullable[String] and
+      (__ \"email").readNullable[String]
+    )(ContactDetailsModel.apply _)
+
+  implicit val writes = Json.writes[ContactDetailsModel]
+}
+
+case class ContactNameModel (name1 : String,
+                             name2: Option[String])
+
+object ContactNameModel {
+
+  implicit val reads: Reads[ContactNameModel] = (
+    (__ \"firstName").read[String] and
+      (__ \"lastName").readNullable[String]
+    )(ContactNameModel.apply _)
+
+  implicit val writes = Json.writes[ContactNameModel]
+}
+
+case class CorrespondenceDetailsModel (contactName: Option[ContactNameModel],
+                                       contactDetails: Option[ContactDetailsModel],
+                                       contactAddress: Option[ContactAddressModel])
+
+object CorrespondenceDetailsModel {
+
+  implicit val reads: Reads[CorrespondenceDetailsModel] = (
+    (__ \"contactDetails").readNullable[ContactNameModel] and
+      (__ \"contactDetails").readNullable[ContactDetailsModel] and
+      (__ \"correspondenceAddress").readNullable[ContactAddressModel]
+    )(CorrespondenceDetailsModel.apply _)
+
+  implicit val writes = Json.writes[CorrespondenceDetailsModel]
+
+}
+
+case class SubscriptionTypeModel (correspondenceDetails: CorrespondenceDetailsModel)
+
+object SubscriptionTypeModel {
+
+  implicit val formats = Json.format[SubscriptionTypeModel]
+}

--- a/app/models/etmp/SubscriptionTypeModel.scala
+++ b/app/models/etmp/SubscriptionTypeModel.scala
@@ -40,9 +40,23 @@ case class ContactAddressModel (addressLine1 : String,
                                 countryCode : String,
                                 postalCode: Option[String])
 
-object ContactAddressModel {
+case class ContactDetailsModel (phoneNumber : Option[String],
+                                mobileNumber: Option[String],
+                                faxNumber : Option[String],
+                                emailAddress: Option[String])
 
-  implicit val reads: Reads[ContactAddressModel] = (
+case class ContactNameModel (name1 : String,
+                             name2: Option[String])
+
+case class CorrespondenceDetailsModel (contactName: Option[ContactNameModel],
+                                       contactDetails: Option[ContactDetailsModel],
+                                       contactAddress: Option[ContactAddressModel])
+
+case class SubscriptionTypeModel (correspondenceDetails: CorrespondenceDetailsModel)
+
+object SubscriptionTypeModel {
+
+  implicit val careads: Reads[ContactAddressModel] = (
     (__ \"addressline1").read[String] and
       (__ \"addressline2").read[String] and
       (__ \"addressline3").readNullable[String] and
@@ -51,58 +65,31 @@ object ContactAddressModel {
       (__ \"postcode").readNullable[String]
     )(ContactAddressModel.apply _)
 
-  implicit val writes = Json.writes[ContactAddressModel]
-}
+  implicit val cawrites = Json.writes[ContactAddressModel]
 
-case class ContactDetailsModel (phoneNumber : Option[String],
-                                mobileNumber: Option[String],
-                                faxNumber : Option[String],
-                                emailAddress: Option[String])
-
-object ContactDetailsModel {
-
-  implicit val reads: Reads[ContactDetailsModel] = (
+  implicit val cdreads: Reads[ContactDetailsModel] = (
     (__ \"telephoneNumber").readNullable[String] and
       (__ \"telephoneNumber2").readNullable[String] and
       (__ \"faxNumber").readNullable[String] and
       (__ \"email").readNullable[String]
     )(ContactDetailsModel.apply _)
 
-  implicit val writes = Json.writes[ContactDetailsModel]
-}
+  implicit val cdwrites = Json.writes[ContactDetailsModel]
 
-case class ContactNameModel (name1 : String,
-                             name2: Option[String])
-
-object ContactNameModel {
-
-  implicit val reads: Reads[ContactNameModel] = (
+  implicit val cnreads: Reads[ContactNameModel] = (
     (__ \"firstName").read[String] and
       (__ \"lastName").readNullable[String]
     )(ContactNameModel.apply _)
 
-  implicit val writes = Json.writes[ContactNameModel]
-}
+  implicit val cnwrites = Json.writes[ContactNameModel]
 
-case class CorrespondenceDetailsModel (contactName: Option[ContactNameModel],
-                                       contactDetails: Option[ContactDetailsModel],
-                                       contactAddress: Option[ContactAddressModel])
-
-object CorrespondenceDetailsModel {
-
-  implicit val reads: Reads[CorrespondenceDetailsModel] = (
+  implicit val cdmreads: Reads[CorrespondenceDetailsModel] = (
     (__ \"contactDetails").readNullable[ContactNameModel] and
       (__ \"contactDetails").readNullable[ContactDetailsModel] and
       (__ \"correspondenceAddress").readNullable[ContactAddressModel]
     )(CorrespondenceDetailsModel.apply _)
 
-  implicit val writes = Json.writes[CorrespondenceDetailsModel]
-
-}
-
-case class SubscriptionTypeModel (correspondenceDetails: CorrespondenceDetailsModel)
-
-object SubscriptionTypeModel {
+  implicit val cdmwrites = Json.writes[CorrespondenceDetailsModel]
 
   implicit val formats = Json.format[SubscriptionTypeModel]
 }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -63,24 +63,17 @@ trait SubscriptionService {
     }
   }
 
-  private def getSafeID(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String = {
-    if(registrationReviewDetails.isDefined) registrationReviewDetails.get.safeId
-    else ""
-  }
+  private def getSafeID(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String =
+    registrationReviewDetails.fold("")(_.safeId)
 
-  private def getPostcode(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String = {
-    if(registrationReviewDetails.isDefined) {
-      val postcode = registrationReviewDetails.get.businessAddress.postcode.getOrElse("").replace(" ","")
-      postcode
-    }
-    else ""
-  }
+  private def getPostcode(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String =
+    registrationReviewDetails.fold("")(_.businessAddress.postcode.getOrElse("").replace(" ",""))
 
   private def sendSubscriptionRequest(safeID: String,
                                       postcode: String,
                                       subscriptionTypeModel: Option[IntermediateSubscriptionTypeModel])
                                      (implicit hc: HeaderCarrier): Future[HttpResponse] = {
-    (!safeID.isEmpty,!postcode.isEmpty,subscriptionTypeModel.isDefined) match {
+    (safeID.nonEmpty,postcode.nonEmpty,subscriptionTypeModel.isDefined) match {
       case (true,true,true) => {
         val json = Json.toJson(subscriptionTypeModel.get)
         val targetSubmissionModel = Json.parse(json.toString()).as[SubscriptionTypeModel]

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import common.KeystoreKeys
+import connectors.{KeystoreConnector, SubscriptionConnector}
+import models.etmp._
+import models.{CompanyRegistrationReviewDetailsModel, ContactDetailsSubscriptionModel, ProvideCorrespondAddressModel}
+import play.api.libs.json.Json
+import play.api.mvc.{Result, Results}
+import play.api.http.Status._
+import uk.gov.hmrc.play.http.HeaderCarrier
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+
+object SubscriptionService extends SubscriptionService {
+  override val subscriptionConnector = SubscriptionConnector
+  override val keystoreConnector = KeystoreConnector
+  override val registeredBusinessCustomerService = RegisteredBusinessCustomerService
+}
+
+trait SubscriptionService {
+
+  val subscriptionConnector: SubscriptionConnector
+  val keystoreConnector: KeystoreConnector
+  val registeredBusinessCustomerService: RegisteredBusinessCustomerService
+
+  def subscribe()(implicit hc: HeaderCarrier): Future[Result] = {
+    for {
+      registrationReviewDetails <- registeredBusinessCustomerService.getReviewBusinessCustomerDetails
+      correspondenceAddress <- keystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel](KeystoreKeys.provideCorrespondAddress)
+      contactDetails <- keystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel](KeystoreKeys.contactDetailsSubscription)
+      result <- sendSubscriptionRequest(
+        getSafeID(registrationReviewDetails),
+        getPostcode(registrationReviewDetails),
+        createSubscriptionRequestModel(correspondenceAddress,contactDetails)
+      )
+    } yield result
+  }
+
+  private def createSubscriptionRequestModel(correspondenceAddress: Option[ProvideCorrespondAddressModel],
+                                     contactDetails: Option[ContactDetailsSubscriptionModel]): Option[IntermediateSubscriptionTypeModel] = {
+    (correspondenceAddress, contactDetails) match {
+      case (Some(address), Some(contact)) =>
+        Some(IntermediateSubscriptionTypeModel(
+            IntermediateCorrespondenceDetailsModel(address,contact)))
+      case (_,_) => None
+    }
+  }
+
+  private def getSafeID(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String = {
+    if(registrationReviewDetails.isDefined) registrationReviewDetails.get.safeId
+    else ""
+  }
+
+  private def getPostcode(registrationReviewDetails: Option[CompanyRegistrationReviewDetailsModel]): String = {
+    if(registrationReviewDetails.isDefined) {
+      val postcode = registrationReviewDetails.get.businessAddress.postcode.getOrElse("").replace(" ","")
+      postcode
+    }
+    else ""
+  }
+
+  private def sendSubscriptionRequest(safeID: String,
+                                      postcode: String,
+                                      subscriptionTypeModel: Option[IntermediateSubscriptionTypeModel])
+                                     (implicit hc: HeaderCarrier): Future[Result] = {
+    (!safeID.isEmpty,subscriptionTypeModel.isDefined) match {
+      case (true,true) => {
+        val json = Json.toJson(subscriptionTypeModel.get)
+        val targetSubmissionModel = Json.parse(json.toString()).as[SubscriptionTypeModel]
+        subscriptionConnector.subscribe(targetSubmissionModel,safeID,postcode).map {
+          response => response.status match {
+            case OK => Results.Ok
+            case _ => Results.InternalServerError
+          }
+        }
+      }
+      case (_,_) => Future.successful(Results.InternalServerError)
+    }
+  }
+
+}

--- a/app/utils/Validation.scala
+++ b/app/utils/Validation.scala
@@ -265,7 +265,7 @@ object Validation {
   def postcodeCountryCheckConstraint: Constraint[ProvideCorrespondAddressModel] = {
     Constraint("constraints.postcodeCountryCheck")({
       provideCorrespondAddressForm: ProvideCorrespondAddressModel =>
-        if (provideCorrespondAddressForm.countryCode.length > 0 && provideCorrespondAddressForm.postcode.isDefined) {
+        if (provideCorrespondAddressForm.countryCode.length > 0 && provideCorrespondAddressForm.postcode.isDefined) { //TODO: Is this correct?
           Invalid(Seq(ValidationError(Messages("validation.error.countrypostcode"))))
         } else {
           Valid

--- a/app/utils/Validation.scala
+++ b/app/utils/Validation.scala
@@ -265,7 +265,7 @@ object Validation {
   def postcodeCountryCheckConstraint: Constraint[ProvideCorrespondAddressModel] = {
     Constraint("constraints.postcodeCountryCheck")({
       provideCorrespondAddressForm: ProvideCorrespondAddressModel =>
-        if (provideCorrespondAddressForm.countryCode.length > 0 && provideCorrespondAddressForm.postcode.length > 0) {
+        if (provideCorrespondAddressForm.countryCode.length > 0 && provideCorrespondAddressForm.postcode.isDefined) {
           Invalid(Seq(ValidationError(Messages("validation.error.countrypostcode"))))
         } else {
           Valid

--- a/app/views/registrationInformation/ConfirmCorrespondAddress.scala.html
+++ b/app/views/registrationInformation/ConfirmCorrespondAddress.scala.html
@@ -1,5 +1,6 @@
 @import models.{ConfirmCorrespondAddressModel,CompanyRegistrationReviewDetailsModel}
 @import common.Constants
+@import utils.CountriesHelper
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers.{errorSummary, formInputRadioGroup, textWithConstErrors, backButtonWithProgress}
 
@@ -29,7 +30,7 @@
             @if(companyDetails.businessAddress.postcode.isDefined){
             <span id="postcode" class="form-hint">@companyDetails.businessAddress.postcode</span>
             }
-            <span id="country" class="form-hint">@companyDetails.businessAddress.country</span>
+            <span id="country" class="form-hint">@CountriesHelper.getSelectedCountry(companyDetails.businessAddress.country)</span>
         </div>
 
         @form(action = controllers.routes.ConfirmCorrespondAddressController.submit()) {

--- a/app/views/registrationInformation/ReviewCompanyDetails.scala.html
+++ b/app/views/registrationInformation/ReviewCompanyDetails.scala.html
@@ -54,12 +54,13 @@
                 </tbody>
             </table>
         </div>
+        @form(action = controllers.routes.ReviewCompanyDetailsController.submit()) {
         <div class="form-group" id="reviewDetailsButtonDiv">
             <button class="btn button" id="submit" type="submit">
                 @Messages("page.registrationInformation.ReviewCompanyDetails.button.continue")
             </button>
         </div>
-
+        }
     </div>
 </div>
 

--- a/app/views/registrationInformation/ReviewCompanyDetails.scala.html
+++ b/app/views/registrationInformation/ReviewCompanyDetails.scala.html
@@ -24,18 +24,16 @@
                     <td id="correspondenceAddress-answer">
                         <p id="addressline1">@reviewCompanyDetails.correspondenceAddress.addressline1</p>
                         <p id="addressline2">@reviewCompanyDetails.correspondenceAddress.addressline2</p>
-                        @if(!reviewCompanyDetails.correspondenceAddress.addressline3.isEmpty()) {
-                        <p id="addressline3">@reviewCompanyDetails.correspondenceAddress.addressline3</p>
+                        @if(reviewCompanyDetails.correspondenceAddress.addressline3.isDefined) {
+                        <p id="addressline3">@reviewCompanyDetails.correspondenceAddress.addressline3.get</p>
                         }
-                        @if(!reviewCompanyDetails.correspondenceAddress.addressline4.isEmpty()) {
-                        <p id="addressline4">@reviewCompanyDetails.correspondenceAddress.addressline4</p>
+                        @if(reviewCompanyDetails.correspondenceAddress.addressline4.isDefined) {
+                        <p id="addressline4">@reviewCompanyDetails.correspondenceAddress.addressline4.get</p>
                         }
-                        @if(!reviewCompanyDetails.correspondenceAddress.postcode.isEmpty()) {
-                        <p id="postcode">@reviewCompanyDetails.correspondenceAddress.postcode</p>
+                        @if(reviewCompanyDetails.correspondenceAddress.postcode.isDefined) {
+                        <p id="postcode">@reviewCompanyDetails.correspondenceAddress.postcode.get</p>
                         }
-                        @if(!reviewCompanyDetails.correspondenceAddress.countryCode.isEmpty()) {
                         <p id="countrycode">@reviewCompanyDetails.correspondenceAddress.countryCode</p>
-                        }
                     </td>
                     <td><a href="@controllers.routes.ProvideCorrespondAddressController.show().url" id="correspondenceAddress-link">Change</a></td>
                 </tr>
@@ -46,8 +44,8 @@
                     <td id="companyContact-answer">
                         <p id="name">@reviewCompanyDetails.contactDetails.firstName @reviewCompanyDetails.contactDetails.lastName</p>
                         <p id="telephonenumber">@reviewCompanyDetails.contactDetails.telephoneNumber</p>
-                        @if(!reviewCompanyDetails.contactDetails.telephoneNumber2.isEmpty()) {
-                        <p id="telephonenumber2">@reviewCompanyDetails.contactDetails.telephoneNumber2</p>
+                        @if(reviewCompanyDetails.contactDetails.telephoneNumber2.isDefined) {
+                        <p id="telephonenumber2">@reviewCompanyDetails.contactDetails.telephoneNumber2.get</p>
                         }
                         <p id="email">@reviewCompanyDetails.contactDetails.email</p>
                     </td>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,6 +22,7 @@ GET        /contact-details-subscription            controllers.ContactDetailsSu
 POST       /contact-details-subscription            controllers.ContactDetailsSubscriptionController.submit
 
 GET        /review-company-details                  controllers.ReviewCompanyDetailsController.show
+POST       /review-company-details                  controllers.ReviewCompanyDetailsController.submit
 
 #Session Timeout route
 #####################################################################################################################

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -108,3 +108,7 @@ introduction {
 business-customer {
   url="http://localhost:9923/business-customer/investment-tax-relief"
 }
+
+submission {
+  url="http://localhost:9635/investment-tax-relief/your-company-need"
+}

--- a/test/auth/MockConfig.scala
+++ b/test/auth/MockConfig.scala
@@ -29,4 +29,5 @@ object MockConfig extends AppConfig {
   override val ggSignInUrl: String = "/gg/sign-in"
   override val introductionUrl: String = "http://localhost:9637/investment-tax-relief-subscription/"
   override val businessCustomerUrl: String = "http://localhost:9923/business-customer/investment-tax-relief"
+  override val submissionUrl: String = "/investment-tax-relief/"
 }

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.WSHttp
+import models.etmp.{CorrespondenceDetailsModel, SubscriptionTypeModel}
+import org.mockito.Matchers
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import play.api.libs.json.JsValue
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.http.ws.WSHttp
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import play.api.test.Helpers._
+
+class SubscriptionConnectorSpec extends UnitSpec with WithFakeApplication with ServicesConfig with MockitoSugar {
+
+  lazy val mockHttp = mock[WSHttp]
+  implicit val hc = new HeaderCarrier()
+  val safeID = "ABC123"
+  val postcode = "AB11AB"
+  val url = "localhost"
+  val subscriptionModel = SubscriptionTypeModel(CorrespondenceDetailsModel(None,None,None))
+
+  object TestConnector extends SubscriptionConnector {
+    override lazy val http = mockHttp
+    override lazy val serviceUrl = url
+  }
+
+  "SubscriptionConnector" should {
+
+    "Use WSHttp" in {
+      SubscriptionConnector.http shouldBe WSHttp
+    }
+
+    "Use base url for investment-tax-relief-subscription" in {
+      SubscriptionConnector.serviceUrl shouldBe baseUrl("investment-tax-relief-subscription")
+    }
+
+  }
+
+  "subscribe" should {
+
+    lazy val result = TestConnector.subscribe(subscriptionModel,safeID,postcode)
+
+    "create a url using the safeID and postcode" in {
+      when(mockHttp.POST[JsValue, HttpResponse](Matchers.eq(s"$url/investment-tax-relief-subscription/$safeID/$postcode/subscribe"),
+        Matchers.any(),Matchers.any())(Matchers.any(),Matchers.any(),Matchers.any())).thenReturn(HttpResponse(OK))
+      await(result).status shouldBe OK
+    }
+
+  }
+
+}

--- a/test/controllers/ContactDetailsSubscriptionControllerSpec.scala
+++ b/test/controllers/ContactDetailsSubscriptionControllerSpec.scala
@@ -48,9 +48,9 @@ class ContactDetailsSubscriptionControllerSpec extends UnitSpec with MockitoSuga
     override lazy val registeredBusinessCustomerService = mockRegisteredBusinessCustomerService
   }
 
-  val model = ContactDetailsSubscriptionModel("Dagumi","Fujiwara","86","86","dagumi.tofuboy@akinaSpeedStars.com")
+  val model = ContactDetailsSubscriptionModel("Dagumi","Fujiwara","86",Some("86"),"dagumi.tofuboy@akinaSpeedStars.com")
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(model)))
-  val keyStoreSavedContactDetailsSubscription = ContactDetailsSubscriptionModel("Dagumi","Fujiwara","86","86","dagumi.tofuboy@akinaSpeedStars.com")
+  val keyStoreSavedContactDetailsSubscription = ContactDetailsSubscriptionModel("Dagumi","Fujiwara","86",Some("86"),"dagumi.tofuboy@akinaSpeedStars.com")
 
   implicit val hc = HeaderCarrier()
 

--- a/test/controllers/ProvideCorrespondAddressControllerSpec.scala
+++ b/test/controllers/ProvideCorrespondAddressControllerSpec.scala
@@ -48,9 +48,9 @@ class ProvideCorrespondAddressControllerSpec extends UnitSpec with MockitoSugar 
     override lazy val registeredBusinessCustomerService = mockRegisteredBusinessCustomerService
   }
 
-  val model = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina","","","","JP")
+  val model = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina",None,None,None,"JP")
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(model)))
-  val keyStoreSavedProvideCorrespondAddress = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina","","","","JP")
+  val keyStoreSavedProvideCorrespondAddress = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina",None,None,None,"JP")
 
   implicit val hc = HeaderCarrier()
 

--- a/test/controllers/ReviewCompanyDetailsControllerSpec.scala
+++ b/test/controllers/ReviewCompanyDetailsControllerSpec.scala
@@ -44,17 +44,17 @@ class ReviewCompanyDetailsControllerSpec extends UnitSpec with FakeRequestHelper
     withRegDetails()
     when(TestController.keystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
       (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2","test3","test4","test5","test6")))
+      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2",Some("test3"),Some("test4"),Some("test5"),"test6")))
     when(TestController.keystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
       (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ContactDetailsSubscriptionModel("test1","test2","test3","test4","test5")))
+      .thenReturn(Some(ContactDetailsSubscriptionModel("test1","test2","test3",Some("test4"),"test5")))
   }
 
   def notAllDetails(): Unit = {
     withRegDetails()
     when(TestController.keystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
       (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2","test3","test4","test5","test6")))
+      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2",Some("test3"),Some("test4"),Some("test5"),"test6")))
     when(TestController.keystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
       (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
       .thenReturn(None)

--- a/test/controllers/ReviewCompanyDetailsControllerSpec.scala
+++ b/test/controllers/ReviewCompanyDetailsControllerSpec.scala
@@ -21,43 +21,28 @@ import config.{FrontendAppConfig, FrontendAuthConnector}
 import helpers.FakeRequestHelper
 import connectors.KeystoreConnector
 import helpers.AuthHelper._
+import helpers.KeystoreHelper._
 import play.api.test.Helpers._
 import common.Encoder._
-import common.KeystoreKeys
-import org.mockito.Mockito._
-import models.{ContactDetailsSubscriptionModel, ProvideCorrespondAddressModel}
 import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import services.RegisteredBusinessCustomerService
+import services.{RegisteredBusinessCustomerService, SubscriptionService}
+import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
+import scala.concurrent.Future
+
 class ReviewCompanyDetailsControllerSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  lazy val mockSubscriptionService = mock[SubscriptionService]
 
   object TestController extends ReviewCompanyDetailsController {
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
-    override val keystoreConnector = mock[KeystoreConnector]
+    override val keystoreConnector = mockKeystoreConnector
     override lazy val registeredBusinessCustomerService = mockRegisteredBusinessCustomerService
-  }
-
-  def allDetails(): Unit = {
-    withRegDetails()
-    when(TestController.keystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
-      (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2",Some("test3"),Some("test4"),Some("test5"),"test6")))
-    when(TestController.keystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
-      (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ContactDetailsSubscriptionModel("test1","test2","test3",Some("test4"),"test5")))
-  }
-
-  def notAllDetails(): Unit = {
-    withRegDetails()
-    when(TestController.keystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
-      (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
-      .thenReturn(Some(ProvideCorrespondAddressModel("test1","test2",Some("test3"),Some("test4"),Some("test5"),"test6")))
-    when(TestController.keystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
-      (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
-      .thenReturn(None)
+    override lazy val subscriptionService = mockSubscriptionService
   }
 
   "ReviewCompanyDetailsController" should {
@@ -75,6 +60,12 @@ class ReviewCompanyDetailsControllerSpec extends UnitSpec with FakeRequestHelper
   "ReviewCompanyDetailsController" should {
     "use the correct registered business customer service" in {
       ReviewCompanyDetailsController.registeredBusinessCustomerService shouldBe RegisteredBusinessCustomerService
+    }
+  }
+
+  "ReviewCompanyDetailsController" should {
+    "use the correct subscription service" in {
+      ReviewCompanyDetailsController.subscriptionService shouldBe SubscriptionService
     }
   }
 
@@ -167,19 +158,33 @@ class ReviewCompanyDetailsControllerSpec extends UnitSpec with FakeRequestHelper
 
   "ReviewCompanyDetailsController.submit" when {
 
-    "Sending a POST request to ReviewCompanyDetailsController" should {
+    "Sending a POST request to ReviewCompanyDetailsController and SubscriptionService returns OK" should {
 
       "return a 303" in {
         withRegDetails()
+        when(mockSubscriptionService.subscribe(Matchers.any())).thenReturn(Future.successful(HttpResponse(OK)))
         submitWithSessionAndAuth(TestController.submit)(
           result => status(result) shouldBe SEE_OTHER
         )
       }
 
-      "redirect to ReviewCompanyDetailsController" in {
+      "redirect to submission frontend" in {
         withRegDetails()
+        when(mockSubscriptionService.subscribe(Matchers.any())).thenReturn(Future.successful(HttpResponse(OK)))
         submitWithSessionAndAuth(TestController.submit)(
-          result => redirectLocation(result) shouldBe Some(routes.ReviewCompanyDetailsController.show().url)
+          result => redirectLocation(result) shouldBe Some(FrontendAppConfig.submissionUrl)
+        )
+      }
+
+    }
+
+    "Sending a POST request to ReviewCompanyDetailsController and SubscriptionService returns a non-OK response" should {
+
+      "return an INTERNAL_SERVER_ERROR" in {
+        withRegDetails()
+        when(mockSubscriptionService.subscribe(Matchers.any())).thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR)))
+        submitWithSessionAndAuth(TestController.submit)(
+          result => status(result) shouldBe INTERNAL_SERVER_ERROR
         )
       }
 

--- a/test/forms/ContactDetailsSubscriptionFormSpec.scala
+++ b/test/forms/ContactDetailsSubscriptionFormSpec.scala
@@ -32,7 +32,7 @@ class ContactDetailsSubscriptionFormSpec extends UnitSpec {
 
   "Creating a form using a valid model (with telelphone2)" should {
     "return a form with the data specified in the model" in {
-      val model = ContactDetailsSubscriptionModel("Percy", "Montague", "06472 778833", "06472 123998", "harry@wishingwell.com")
+      val model = ContactDetailsSubscriptionModel("Percy", "Montague", "06472 778833", Some("06472 123998"), "harry@wishingwell.com")
       val form = contactDetailsSubscriptionForm.fill(model)
       form.data("firstName") shouldBe "Percy"
       form.data("lastName") shouldBe "Montague"
@@ -45,13 +45,13 @@ class ContactDetailsSubscriptionFormSpec extends UnitSpec {
 
   "Creating a form using a valid model (no telelphone2)" should {
     "return a form with the data specified in the model" in {
-      val model = ContactDetailsSubscriptionModel("Percy", "Montague", "06472 778833", "", "harry@wishingwell.com")
+      val model = ContactDetailsSubscriptionModel("Percy", "Montague", "06472 778833", None, "harry@wishingwell.com")
       val form = contactDetailsSubscriptionForm.fill(model)
       form.data("firstName") shouldBe "Percy"
       form.data("lastName") shouldBe "Montague"
       form.data("telephoneNumber") shouldBe "06472 778833"
-      form.data("telephoneNumber2") shouldBe ""
       form.data("email") shouldBe "harry@wishingwell.com"
+      form.data.size shouldBe 4
       form.errors.length shouldBe 0
     }
   }

--- a/test/forms/ProvideCorrespondAddressFormSpec.scala
+++ b/test/forms/ProvideCorrespondAddressFormSpec.scala
@@ -21,7 +21,7 @@ import models.ProvideCorrespondAddressModel
 import play.api.i18n.Messages
 import uk.gov.hmrc.play.test.UnitSpec
 
-class provideCorrespondAddressFormSpec extends UnitSpec {
+class ProvideCorrespondAddressFormSpec extends UnitSpec {
 
   "Creating a form using an empty model" should {
     lazy val form = provideCorrespondAddressForm
@@ -32,16 +32,14 @@ class provideCorrespondAddressFormSpec extends UnitSpec {
 
   "Creating a form using a valid model" should {
     "return a form with the data specified in the model" in {
-      val model = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina","","","","JP")
+      val model = ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina",None,None,None,"JP")
       val form = provideCorrespondAddressForm.fill(model)
 
       form.data("addressline1") shouldBe "Akina Speed Stars"
       form.data("addressline2") shouldBe "Mt. Akina"
-      form.data("addressline3") shouldBe ""
-      form.data("addressline4") shouldBe ""
-      form.data("postcode") shouldBe ""
       form.data("countryCode") shouldBe "JP"
       form.errors.length shouldBe 0
+      form.data.size shouldBe 3
     }
   }
 

--- a/test/helpers/KeystoreHelper.scala
+++ b/test/helpers/KeystoreHelper.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import common.KeystoreKeys
+import connectors.KeystoreConnector
+import helpers.AuthHelper._
+import models.{ContactDetailsSubscriptionModel, ProvideCorrespondAddressModel}
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+
+import scala.concurrent.Future
+
+object KeystoreHelper extends MockitoSugar {
+
+  lazy val mockKeystoreConnector = mock[KeystoreConnector]
+  val provideModel = ProvideCorrespondAddressModel("test1","test2",Some("test3"),Some("test4"),Some("test5"),"test6")
+  val contactDetailsModel = ContactDetailsSubscriptionModel("test1","test2","test3",Some("test4"),"test5")
+
+  def allDetails(): Unit = {
+    withRegDetails()
+    when(mockKeystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
+      (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(Some(provideModel)))
+    when(mockKeystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
+      (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(Some(contactDetailsModel)))
+  }
+
+  def notAllDetails(): Unit = {
+    withRegDetails()
+    when(mockKeystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
+      (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(Some(provideModel)))
+    when(mockKeystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
+      (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(None))
+  }
+
+  def noDetails(): Unit = {
+    noRegDetails()
+    when(mockKeystoreConnector.fetchAndGetFormData[ProvideCorrespondAddressModel]
+      (Matchers.contains(KeystoreKeys.provideCorrespondAddress))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(Some(provideModel)))
+    when(mockKeystoreConnector.fetchAndGetFormData[ContactDetailsSubscriptionModel]
+      (Matchers.contains(KeystoreKeys.contactDetailsSubscription))(Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(None))
+  }
+
+}

--- a/test/models/etmp/SubscriptionModelSpec.scala
+++ b/test/models/etmp/SubscriptionModelSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.etmp
+
+import models.{ContactDetailsSubscriptionModel, ProvideCorrespondAddressModel}
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+
+class SubscriptionModelSpec extends UnitSpec {
+
+  val maxProvideCorrespondAddressModel = ProvideCorrespondAddressModel("line1","line2",Some("line3"),Some("line4"),Some("AB1 1AB"),"GB")
+  val maxContactDetailsSubscriptionModel = ContactDetailsSubscriptionModel("first","last","01234567890",Some("09876543210"),"email@email.com")
+  val maxIntermediateCorrespondenceDetailsModel = IntermediateCorrespondenceDetailsModel(maxProvideCorrespondAddressModel,maxContactDetailsSubscriptionModel)
+  val maxIntermediateSubscriptionTypeModel = IntermediateSubscriptionTypeModel(maxIntermediateCorrespondenceDetailsModel)
+
+  val minProvideCorrespondAddressModel = ProvideCorrespondAddressModel("line1","line2",None,None,None,"AA")
+  val minContactDetailsSubscriptionModel = ContactDetailsSubscriptionModel("first","last","01234567890",None,"email@email.com")
+  val minIntermediateCorrespondenceDetailsModel = IntermediateCorrespondenceDetailsModel(minProvideCorrespondAddressModel,minContactDetailsSubscriptionModel)
+  val minIntermediateSubscriptionTypeModel = IntermediateSubscriptionTypeModel(minIntermediateCorrespondenceDetailsModel)
+
+  val maxContactAddress = ContactAddressModel("line1","line2",Some("line3"),Some("line4"),"GB",Some("AB1 1AB"))
+  val maxContactDetails = ContactDetailsModel(Some("01234567890"),Some("09876543210"),None,Some("email@email.com"))
+  val maxContactName = ContactNameModel("first",Some("last"))
+
+  val minContactAddress = ContactAddressModel("line1","line2",None,None,"AA",None)
+  val minContactDetails = ContactDetailsModel(Some("01234567890"),None,None,Some("email@email.com"))
+  val minContactName = ContactNameModel("first",Some("last"))
+
+  "CorrespondenceDetailsModel" when {
+
+    "Converting from IntermediateCorrespondenceDetailsModel to CorrespondenceDetailsModel with all optional values" should {
+
+      lazy val old = Json.toJson(maxIntermediateCorrespondenceDetailsModel)
+      lazy val result = Json.parse(old.toString).as[CorrespondenceDetailsModel]
+
+      "Convert the contact address correctly" in {
+        await(result).contactAddress.get shouldBe maxContactAddress
+      }
+
+      "Convert the contact details correctly" in {
+        await(result).contactDetails.get shouldBe maxContactDetails
+      }
+
+      "Convert the contact name correctly" in {
+        await(result).contactName.get shouldBe maxContactName
+      }
+
+    }
+
+    "Converting from IntermediateCorrespondenceDetailsModel to CorrespondenceDetailsModel with no optional values" should {
+
+      lazy val old = Json.toJson(minIntermediateCorrespondenceDetailsModel)
+      lazy val result = Json.parse(old.toString).as[CorrespondenceDetailsModel]
+
+      "Convert the contact address correctly" in {
+        await(result).contactAddress.get shouldBe minContactAddress
+      }
+
+      "Convert the contact details correctly" in {
+        await(result).contactDetails.get shouldBe minContactDetails
+      }
+
+      "Convert the contact name correctly" in {
+        await(result).contactName.get shouldBe minContactName
+      }
+
+    }
+  }
+
+  "SubscriptionTypeModel" when {
+
+    "Converting from IntermediateSubscriptionTypeModel to SubscriptionTypeModel with all optional values" should {
+
+      lazy val old = Json.toJson(maxIntermediateSubscriptionTypeModel)
+      lazy val result = Json.parse(old.toString).as[SubscriptionTypeModel]
+
+      "Convert the contact address correctly" in {
+        await(result).correspondenceDetails.contactAddress.get shouldBe maxContactAddress
+      }
+
+      "Convert the contact details correctly" in {
+        await(result).correspondenceDetails.contactDetails.get shouldBe maxContactDetails
+      }
+
+      "Convert the contact name correctly" in {
+        await(result).correspondenceDetails.contactName.get shouldBe maxContactName
+      }
+
+    }
+
+    "Converting from IntermediateSubscriptionTypeModel to SubscriptionTypeModel with no optional values" should {
+
+      lazy val old = Json.toJson(minIntermediateSubscriptionTypeModel)
+      lazy val result = Json.parse(old.toString).as[SubscriptionTypeModel]
+
+      "Convert the contact address correctly" in {
+        await(result).correspondenceDetails.contactAddress.get shouldBe minContactAddress
+      }
+
+      "Convert the contact details correctly" in {
+        await(result).correspondenceDetails.contactDetails.get shouldBe minContactDetails
+      }
+
+      "Convert the contact name correctly" in {
+        await(result).correspondenceDetails.contactName.get shouldBe minContactName
+      }
+
+    }
+  }
+
+}

--- a/test/models/etmp/SubscriptionModelSpec.scala
+++ b/test/models/etmp/SubscriptionModelSpec.scala
@@ -40,47 +40,6 @@ class SubscriptionModelSpec extends UnitSpec {
   val minContactDetails = ContactDetailsModel(Some("01234567890"),None,None,Some("email@email.com"))
   val minContactName = ContactNameModel("first",Some("last"))
 
-  "CorrespondenceDetailsModel" when {
-
-    "Converting from IntermediateCorrespondenceDetailsModel to CorrespondenceDetailsModel with all optional values" should {
-
-      lazy val old = Json.toJson(maxIntermediateCorrespondenceDetailsModel)
-      lazy val result = Json.parse(old.toString).as[CorrespondenceDetailsModel]
-
-      "Convert the contact address correctly" in {
-        await(result).contactAddress.get shouldBe maxContactAddress
-      }
-
-      "Convert the contact details correctly" in {
-        await(result).contactDetails.get shouldBe maxContactDetails
-      }
-
-      "Convert the contact name correctly" in {
-        await(result).contactName.get shouldBe maxContactName
-      }
-
-    }
-
-    "Converting from IntermediateCorrespondenceDetailsModel to CorrespondenceDetailsModel with no optional values" should {
-
-      lazy val old = Json.toJson(minIntermediateCorrespondenceDetailsModel)
-      lazy val result = Json.parse(old.toString).as[CorrespondenceDetailsModel]
-
-      "Convert the contact address correctly" in {
-        await(result).contactAddress.get shouldBe minContactAddress
-      }
-
-      "Convert the contact details correctly" in {
-        await(result).contactDetails.get shouldBe minContactDetails
-      }
-
-      "Convert the contact name correctly" in {
-        await(result).contactName.get shouldBe minContactName
-      }
-
-    }
-  }
-
   "SubscriptionTypeModel" when {
 
     "Converting from IntermediateSubscriptionTypeModel to SubscriptionTypeModel with all optional values" should {

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.{KeystoreConnector, SubscriptionConnector}
+import helpers.KeystoreHelper._
+import helpers.AuthHelper._
+import models.etmp.{IntermediateCorrespondenceDetailsModel, IntermediateSubscriptionTypeModel, SubscriptionTypeModel}
+import org.mockito.Matchers
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
+
+class SubscriptionServiceSpec extends UnitSpec with MockitoSugar with WithFakeApplication {
+
+  lazy val mockSubConnector = mock[SubscriptionConnector]
+  implicit val hc = new HeaderCarrier()
+  val subscriptionModel = Json.parse(
+    Json.toJson(
+      IntermediateSubscriptionTypeModel(IntermediateCorrespondenceDetailsModel(provideModel,contactDetailsModel))
+    ).toString()
+  ).as[SubscriptionTypeModel]
+
+  object TestService extends SubscriptionService {
+    override lazy val subscriptionConnector = mockSubConnector
+    override lazy val keystoreConnector = mockKeystoreConnector
+    override lazy val registeredBusinessCustomerService = mockRegisteredBusinessCustomerService
+  }
+
+  "SubscriptionService" should {
+
+    "Use SubscriptionConnector" in {
+      SubscriptionService.subscriptionConnector shouldBe SubscriptionConnector
+    }
+
+    "Use KeystoreConnector" in {
+      SubscriptionService.keystoreConnector shouldBe KeystoreConnector
+    }
+
+    "Use RegisteredBusinessCustomerService" in {
+      SubscriptionService.registeredBusinessCustomerService shouldBe RegisteredBusinessCustomerService
+    }
+
+  }
+
+  "subscribe" when {
+
+    "All details can be retrieved from keystore" should {
+
+      lazy val result = TestService.subscribe
+
+      "Make a successful request to the subscription backend" in {
+        allDetails()
+        when(mockSubConnector.subscribe(Matchers.eq(subscriptionModel),Matchers.eq(validModel.safeId),
+          Matchers.eq(validModel.businessAddress.postcode.get.replace(" ","")))(Matchers.any()))
+          .thenReturn(Future.successful(HttpResponse(OK)))
+        await(result).status shouldBe OK
+      }
+    }
+
+    "Not all details can be retrieved from keystore" should {
+
+      lazy val result = TestService.subscribe
+
+      "Make no request to the subscription backend" in {
+        notAllDetails()
+        await(result).status shouldBe INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "No details can be retrieved from keystore" should {
+
+      lazy val result = TestService.subscribe
+
+      "Make no request to the subscription backend" in {
+        noDetails()
+        await(result).status shouldBe INTERNAL_SERVER_ERROR
+      }
+    }
+
+  }
+
+}

--- a/test/views/ConfirmCorrespondAddressSpec.scala
+++ b/test/views/ConfirmCorrespondAddressSpec.scala
@@ -28,6 +28,7 @@ import org.scalatest.mock.MockitoSugar
 import play.api.i18n.Messages
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import utils.CountriesHelper
 import views.html.registrationInformation.ConfirmCorrespondAddress
 
 
@@ -67,7 +68,7 @@ class ConfirmCorrespondAddressSpec extends UnitSpec with MockitoSugar with WithF
       document.body.getElementById("businessAddress3").text shouldBe validModel.businessAddress.line_3.get
       document.body.getElementById("businessAddress4").text shouldBe validModel.businessAddress.line_4.get
       document.body.getElementById("postcode").text shouldBe validModel.businessAddress.postcode.get
-      document.body.getElementById("country").text shouldBe validModel.businessAddress.country
+      document.body.getElementById("country").text shouldBe CountriesHelper.getSelectedCountry(validModel.businessAddress.country)
       document.body.getElementById("storedAddressDiv").children().size() shouldBe 7
       document.body.getElementById("get-help-action").text shouldBe Messages("common.error.help.text")
     }
@@ -88,7 +89,7 @@ class ConfirmCorrespondAddressSpec extends UnitSpec with MockitoSugar with WithF
       document.body.select("#contactAddressUse-yes").size() shouldBe 1
       document.body.select("#contactAddressUse-no").size() shouldBe 1
       document.body.getElementById("storedAddressDiv").children().size() shouldBe 4
-      document.body.getElementById("country").text shouldBe validModelMin.businessAddress.country
+      document.body.getElementById("country").text shouldBe CountriesHelper.getSelectedCountry(validModelMin.businessAddress.country)
       document.body.getElementById("get-help-action").text shouldBe Messages("common.error.help.text")
     }
 
@@ -113,7 +114,7 @@ class ConfirmCorrespondAddressSpec extends UnitSpec with MockitoSugar with WithF
       document.body.getElementById("businessAddress3").text shouldBe validModel.businessAddress.line_3.get
       document.body.getElementById("businessAddress4").text shouldBe validModel.businessAddress.line_4.get
       document.body.getElementById("postcode").text shouldBe validModel.businessAddress.postcode.get
-      document.body.getElementById("country").text shouldBe validModel.businessAddress.country
+      document.body.getElementById("country").text shouldBe CountriesHelper.getSelectedCountry(validModel.businessAddress.country)
       document.body.getElementById("get-help-action").text shouldBe  Messages("common.error.help.text")
       document.getElementById("error-summary-display").hasClass("error-summary--show")
     }

--- a/test/views/ContactDetailsSubscriptionSpec.scala
+++ b/test/views/ContactDetailsSubscriptionSpec.scala
@@ -33,7 +33,9 @@ class ContactDetailsSubscriptionSpec extends UnitSpec with WithFakeApplication w
 
     "Verify that the contact details page contains the correct elements when a valid ContactDetailsSubscriptionModel is passed" in {
 
-      val contactDetailsSubscriptionModel = new ContactDetailsSubscriptionModel("Jeff","Stelling","01384 555678", "01783432876", "Jeff.Stelling@HMRC.gov.uk")
+      val contactDetailsSubscriptionModel = new ContactDetailsSubscriptionModel(
+        "Jeff","Stelling","01384 555678", Some("01783432876"), "Jeff.Stelling@HMRC.gov.uk"
+      )
       lazy val form = contactDetailsSubscriptionForm.fill(contactDetailsSubscriptionModel)
       lazy val page = ContactDetailsSubscription(form)(authorisedFakeRequest)
       lazy val document = Jsoup.parse(page.body)
@@ -53,7 +55,7 @@ class ContactDetailsSubscriptionSpec extends UnitSpec with WithFakeApplication w
 
     "Verify that the contact details page contains the correct elements when a valid (empty) ContactDetailsSubscriptionModel is passed" in {
 
-      val emptyForm = contactDetailsSubscriptionForm.fill(new ContactDetailsSubscriptionModel("", "" , "", "", ""))
+      val emptyForm = contactDetailsSubscriptionForm.fill(new ContactDetailsSubscriptionModel("", "" , "", None, ""))
       lazy val page = ContactDetailsSubscription(emptyForm)(authorisedFakeRequest)
       lazy val document = Jsoup.parse(page.body)
 

--- a/test/views/ProvideCorrespondAddressSpec.scala
+++ b/test/views/ProvideCorrespondAddressSpec.scala
@@ -32,8 +32,8 @@ class ProvideCorrespondAddressSpec extends UnitSpec with MockitoSugar with WithF
 
   val mockKeystoreConnector = mock[KeystoreConnector]
 
-  val provideCorrespondAddressModel = new ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina","","","","JP")
-  val emptyProvideCorrespondAddressModel = new ProvideCorrespondAddressModel("","","","","","")
+  val provideCorrespondAddressModel = new ProvideCorrespondAddressModel("Akina Speed Stars","Mt. Akina",None,None,None,"JP")
+  val emptyProvideCorrespondAddressModel = new ProvideCorrespondAddressModel("","",None,None,None,"")
 
   lazy val form = provideCorrespondAddressForm.bind(Map("addressline1" -> "Akina Speed Stars",
                                                         "addressline2" -> "Mt. Akina",
@@ -76,9 +76,9 @@ class ProvideCorrespondAddressSpec extends UnitSpec with MockitoSugar with WithF
       document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.registration")
       document.body.getElementById("addressline1").`val`() shouldBe provideCorrespondAddressModel.addressline1
       document.body.getElementById("addressline2").`val`() shouldBe provideCorrespondAddressModel.addressline2
-      document.body.getElementById("addressline3").`val`() shouldBe provideCorrespondAddressModel.addressline3
-      document.body.getElementById("addressline4").`val`() shouldBe provideCorrespondAddressModel.addressline4
-      document.body.getElementById("postcode").`val`() shouldBe provideCorrespondAddressModel.postcode
+      document.body.getElementById("addressline3").`val`() shouldBe ""
+      document.body.getElementById("addressline4").`val`() shouldBe ""
+      document.body.getElementById("postcode").`val`() shouldBe ""
       document.body.select("select[name=countryCode] option[selected]").`val`() shouldBe provideCorrespondAddressModel.countryCode
       document.body.getElementById("get-help-action").text shouldBe Messages("common.error.help.text")
     }

--- a/test/views/ReviewCompanyDetailsSpec.scala
+++ b/test/views/ReviewCompanyDetailsSpec.scala
@@ -29,11 +29,11 @@ import views.html.registrationInformation.ReviewCompanyDetails
 
 class ReviewCompanyDetailsSpec extends UnitSpec with MockitoSugar with WithFakeApplication with FakeRequestHelper {
 
-  val maxAddress = ProvideCorrespondAddressModel("addressline1","addressline2","addressline3","addressline4","AB1 1AB","GB")
-  val maxContact = ContactDetailsSubscriptionModel("firstname","lastname","01234567890","09876543210","hello@world.com")
+  val maxAddress = ProvideCorrespondAddressModel("addressline1","addressline2",Some("addressline3"),Some("addressline4"),Some("AB1 1AB"),"GB")
+  val maxContact = ContactDetailsSubscriptionModel("firstname","lastname","01234567890",Some("09876543210"),"hello@world.com")
   val maxDetails = ReviewCompanyDetailsModel(validModel,maxAddress,maxContact)
-  val minAddress = ProvideCorrespondAddressModel("addressline1","addressline2","","","","AB")
-  val minContact = ContactDetailsSubscriptionModel("firstname","lastname","01234567890","","hello@world.com")
+  val minAddress = ProvideCorrespondAddressModel("addressline1","addressline2",None,None,None,"AB")
+  val minContact = ContactDetailsSubscriptionModel("firstname","lastname","01234567890",None,"hello@world.com")
   val minDetails = ReviewCompanyDetailsModel(validModel,minAddress,minContact)
   lazy val pageMax = ReviewCompanyDetails(maxDetails)(authorisedFakeRequest)
   lazy val pageMin = ReviewCompanyDetails(minDetails)(authorisedFakeRequest)
@@ -55,16 +55,16 @@ class ReviewCompanyDetailsSpec extends UnitSpec with MockitoSugar with WithFakeA
         document.body.getElementById("correspondenceAddress-answer").children().size() shouldBe 6
         document.body.getElementById("addressline1").text shouldBe maxAddress.addressline1
         document.body.getElementById("addressline2").text shouldBe maxAddress.addressline2
-        document.body.getElementById("addressline3").text shouldBe maxAddress.addressline3
-        document.body.getElementById("addressline4").text shouldBe maxAddress.addressline4
-        document.body.getElementById("postcode").text shouldBe maxAddress.postcode
+        document.body.getElementById("addressline3").text shouldBe maxAddress.addressline3.get
+        document.body.getElementById("addressline4").text shouldBe maxAddress.addressline4.get
+        document.body.getElementById("postcode").text shouldBe maxAddress.postcode.get
         document.body.getElementById("countrycode").text shouldBe maxAddress.countryCode
         document.body.getElementById("companyContact-question").text shouldBe
           Messages("page.registrationInformation.ReviewCompanyDetails.companyContact")
         document.body.getElementById("companyContact-answer").children().size() shouldBe 4
         document.body.getElementById("name").text shouldBe s"${maxContact.firstName} ${maxContact.lastName}"
         document.body.getElementById("telephonenumber").text shouldBe maxContact.telephoneNumber
-        document.body.getElementById("telephonenumber2").text shouldBe maxContact.telephoneNumber2
+        document.body.getElementById("telephonenumber2").text shouldBe maxContact.telephoneNumber2.get
         document.body.getElementById("email").text shouldBe maxContact.email
         document.getElementById("submit").text() shouldBe Messages("page.registrationInformation.ReviewCompanyDetails.button.continue")
         document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.registration")


### PR DESCRIPTION
This pull request contains a large number of changes:
* Review details page now displays country instead of country code
* Confirm correspondence address page now displays country instead of country code
* Subscription target model created to convert keystore data into a model similar to what ETMP requires.
* Subscription service and connector to send and receive data from backend
* Review details controller now calls subscription service and either redirects to submission frontend or returns an error page.
* Provide correspondence address model and contact details model now use Options for optional values
* Refactored loads of tests
* Added loads of tests too