### PR TITLE
TAVC-1553: Added Test Only end-point to clear enrolments

### DIFF
--- a/app/testOnly/connectors/AuthenticatorConnector.scala
+++ b/app/testOnly/connectors/AuthenticatorConnector.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+  * Important:
+  * This is a Test only Connector to reset the Enrolments. It is not used in production
+  */
+package testOnly.connectors
+
+import config.WSHttp
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
+import scala.concurrent.Future
+
+trait AuthenticatorConnector extends ServicesConfig with RawResponseReads {
+
+  val serviceURL: String
+  val refreshURI: String
+  val http: HttpGet with HttpPost
+
+  def refreshProfile()(implicit hc: HeaderCarrier): Future[HttpResponse] =
+    http.POSTEmpty[HttpResponse](s"""$serviceURL/$refreshURI""")
+
+}
+
+object AuthenticatorConnector extends AuthenticatorConnector {
+  val serviceURL = baseUrl("authenticator")
+  val refreshURI = "authenticator/refresh-profile"
+  val http = WSHttp
+}

--- a/app/testOnly/connectors/GgStubsConnector.scala
+++ b/app/testOnly/connectors/GgStubsConnector.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+  * Important:
+  * This is a Test only Connector to reset the Enrolments. It is not used in production
+  */
+package testOnly.connectors
+
+import config.WSHttp
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, _}
+import scala.concurrent.Future
+
+trait GgStubsConnector extends ServicesConfig with RawResponseReads {
+
+  val serviceURL: String
+  val resetURI: String
+  val http: HttpGet with HttpPost
+
+  def resetEnrolments()(implicit hc: HeaderCarrier): Future[HttpResponse] =
+    http.POSTEmpty(s"$serviceURL/$resetURI")
+
+}
+
+object GgStubsConnector extends GgStubsConnector {
+  val serviceURL = baseUrl("government-gateway-stubs")
+  val resetURI = "test-only/with-refreshed-enrolments/false"
+  val http = WSHttp
+}

--- a/app/testOnly/connectors/RawResponseReads.scala
+++ b/app/testOnly/connectors/RawResponseReads.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.connectors
+
+import uk.gov.hmrc.play.http.{HttpReads, HttpResponse}
+
+trait RawResponseReads {
+
+  implicit val httpReads: HttpReads[HttpResponse] = new HttpReads[HttpResponse] {
+    override def read(method: String, url: String, response: HttpResponse) = response
+  }
+
+}

--- a/app/testOnly/controllers/ResetEnrolmentsController.scala
+++ b/app/testOnly/controllers/ResetEnrolmentsController.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+  * Important:
+  * This is a Test only Controller to reset the Enrolments. It is not used in production
+  */
+package testOnly.controllers
+
+import play.api.mvc.{Action, AnyContent}
+import testOnly.connectors.{AuthenticatorConnector, GgStubsConnector}
+import uk.gov.hmrc.play.frontend.controller.FrontendController
+
+trait ResetEnrolmentsController extends FrontendController {
+
+  val ggStubsConnector: GgStubsConnector
+  val authenticatorConnector: AuthenticatorConnector
+
+  val resetEnrolments = Action.async { implicit request =>
+    for {
+      ggStubResponse <- ggStubsConnector.resetEnrolments()
+      authRefreshed = authenticatorConnector.refreshProfile().isCompleted
+    } yield ggStubResponse.status match {
+      case OK => Ok("Successfully Reset Enrolments")
+      case _ => BadRequest("Failed to Reset Enrolments")
+    }
+  }
+}
+
+object ResetEnrolmentsController extends ResetEnrolmentsController {
+  override val ggStubsConnector = GgStubsConnector
+  override val authenticatorConnector = AuthenticatorConnector
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,37 @@ application.global=config.FrontendGlobal
 application.session.httpOnly=true
 play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9032 localhost:9250 www.google-analytics.com data:"
 
+Dev {
+  microservice {
+    services {
+      government-gateway-stubs {
+        host = localhost
+        port = 8082
+      }
 
+      authenticator {
+        host = localhost
+        port = 9905
+      }
+    }
+  }
+}
+
+Test {
+  microservice {
+    services {
+      government-gateway-stubs {
+        host = localhost
+        port = 8082
+      }
+
+      authenticator {
+        host = localhost
+        port = 9905
+      }
+    }
+  }
+}
 
 microservice {
     metrics {
@@ -34,7 +64,6 @@ microservice {
         }
     }
 
-  #TODO - change port when set up in service manager
     services {
       cachable.session-cache {
         host = localhost

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -9,7 +9,7 @@
 # !!!WARNING!!! Every route defined in this file MUST be prefixed with "/test-only/". This is because NGINX is blocking every uri containing the string "test-only" in production.
 # Failing to follow this rule may result in test routes deployed in production.
 
-GET        /test-only/reset-enrolments       testOnly.controllers.ResetEnrolmentsController.resetEnrolments
+GET        /test-only/investment-tax-relief/reset-enrolments       testOnly.controllers.ResetEnrolmentsController.resetEnrolments
 
 # Add all the application routes to the prod.routes file
 ->         /                                 prod.Routes

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -1,0 +1,15 @@
+# IF THE MICRO-SERVICE DOES NOT NEED ANY TEST-ONLY END-POINTS (ALWAYS PREFERRED) DELETE THIS FILE.
+
+# !!!WARNING!!! This file MUST NOT be referenced in the "application.conf" file to avoid risk of rolling test routes in the production environment.
+# If you need test routes when running tests in CI make sure that the profile for this micro-service (used by service-manager) defines this router as parameter.
+# To do so add the following line to the micro-service profile: "-Dapplication.router=testOnlyDoNotUseInAppConf.Routes"
+# To start the micro-service locally using the test routes run the following command: "sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes"
+
+# Any test-only end-point should be defined here.
+# !!!WARNING!!! Every route defined in this file MUST be prefixed with "/test-only/". This is because NGINX is blocking every uri containing the string "test-only" in production.
+# Failing to follow this rule may result in test routes deployed in production.
+
+GET        /test-only/reset-enrolments       testOnly.controllers.ResetEnrolmentsController.resetEnrolments
+
+# Add all the application routes to the prod.routes file
+->         /                                 prod.Routes

--- a/test/testOnly/connectors/AuthenticatorConnectorSpec.scala
+++ b/test/testOnly/connectors/AuthenticatorConnectorSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.connectors
+
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.http.logging.SessionId
+import uk.gov.hmrc.play.http.ws.WSHttp
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+class AuthenticatorConnectorSpec extends UnitSpec with MockitoSugar {
+
+  object TestAuthenticatorConnector extends AuthenticatorConnector {
+    val serviceURL = "authenticator"
+    val refreshURI = "authenticator/refresh-profile"
+    val http = mock[WSHttp]
+  }
+
+  implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("session1234")))
+  val jsonError = Json.parse("""{"Message": "Error"}""")
+
+  "Calling refreshProfile()" when {
+
+    "receiving an OK response" should {
+      lazy val result = TestAuthenticatorConnector.refreshProfile()
+      lazy val response = await(result)
+      "Return OK" in {
+        when(TestAuthenticatorConnector.http.POSTEmpty[HttpResponse]
+          (Matchers.eq(s"${TestAuthenticatorConnector.serviceURL}/${TestAuthenticatorConnector.refreshURI}"))(Matchers.any(), Matchers.eq(hc)))
+          .thenReturn(Future.successful(HttpResponse(OK)))
+        val result = TestAuthenticatorConnector.refreshProfile()
+        val response = await(result)
+        response.status shouldBe OK
+      }
+    }
+  }
+
+  "receiving a response other than OK" should {
+    lazy val result = TestAuthenticatorConnector.refreshProfile()
+    lazy val response = await(result)
+
+    "Return OK" in {
+      when(TestAuthenticatorConnector.http.POSTEmpty[HttpResponse]
+        (Matchers.eq(s"${TestAuthenticatorConnector.serviceURL}/${TestAuthenticatorConnector.refreshURI}"))(Matchers.any(), Matchers.eq(hc)))
+        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(jsonError))))
+      response.status shouldBe BAD_REQUEST
+    }
+
+    "Return a JSON response" in {
+      when(TestAuthenticatorConnector.http.POSTEmpty[HttpResponse]
+        (Matchers.eq(s"${TestAuthenticatorConnector.serviceURL}/${TestAuthenticatorConnector.refreshURI}"))(Matchers.any(), Matchers.eq(hc)))
+        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(jsonError))))
+      Json.parse(response.body) shouldBe jsonError
+    }
+  }
+}

--- a/test/testOnly/connectors/GgStubsConnectorSpec.scala
+++ b/test/testOnly/connectors/GgStubsConnectorSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.connectors
+
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.http.logging.SessionId
+import uk.gov.hmrc.play.http.ws.WSHttp
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+class GgStubsConnectorSpec extends UnitSpec with MockitoSugar {
+
+  object TestGgStubsConnector extends GgStubsConnector {
+    val serviceURL = "government-gateway-stubs"
+    val resetURI = "test-only/with-refreshed-enrolments/false"
+    val http = mock[WSHttp]
+  }
+
+  implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("session1234")))
+  val jsonError = Json.parse("""{"Message": "Error"}""")
+
+  "Calling resetEnrolments" when {
+
+    "receiving an OK response" should {
+      lazy val result = TestGgStubsConnector.resetEnrolments()
+      lazy val response = await(result)
+      "Return OK" in {
+        when(TestGgStubsConnector.http.POSTEmpty[HttpResponse]
+          (Matchers.eq(s"${TestGgStubsConnector.serviceURL}/${TestGgStubsConnector.resetURI}"))(Matchers.any(), Matchers.eq(hc)))
+          .thenReturn(Future.successful(HttpResponse(OK)))
+        val result = TestGgStubsConnector.resetEnrolments()
+        val response = await(result)
+        response.status shouldBe OK
+      }
+    }
+  }
+
+  "receiving a response other than OK" should {
+    lazy val result = TestGgStubsConnector.resetEnrolments()
+    lazy val response = await(result)
+
+    "Return OK" in {
+      when(TestGgStubsConnector.http.POSTEmpty[HttpResponse]
+        (Matchers.eq(s"${TestGgStubsConnector.serviceURL}/${TestGgStubsConnector.resetURI}"))(Matchers.any(), Matchers.eq(hc)))
+        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(jsonError))))
+      response.status shouldBe BAD_REQUEST
+    }
+
+    "Return a JSON response" in {
+      when(TestGgStubsConnector.http.POSTEmpty[HttpResponse]
+        (Matchers.eq(s"${TestGgStubsConnector.serviceURL}/${TestGgStubsConnector.resetURI}"))(Matchers.any(), Matchers.eq(hc)))
+        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(jsonError))))
+      Json.parse(response.body) shouldBe jsonError
+    }
+  }
+}

--- a/test/testOnly/controllers/ResetEnrolmentsControllerSpec.scala
+++ b/test/testOnly/controllers/ResetEnrolmentsControllerSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.controllers
+
+import helpers.FakeRequestHelper
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.mockito.stubbing.OngoingStubbing
+import org.scalatest.mock.MockitoSugar
+import testOnly.connectors.{AuthenticatorConnector, GgStubsConnector}
+import uk.gov.hmrc.play.http.logging.SessionId
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import play.mvc.Http.Status._
+import scala.concurrent.Future
+
+class ResetEnrolmentsControllerSpec extends UnitSpec with FakeRequestHelper with WithFakeApplication with MockitoSugar {
+
+  object TestResetEnrolmentsController extends ResetEnrolmentsController {
+    override val ggStubsConnector = mock[GgStubsConnector]
+    override val authenticatorConnector = mock[AuthenticatorConnector]
+  }
+
+  implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("session1234")))
+
+  def mockGgStubsResponse(response: HttpResponse): OngoingStubbing[Future[HttpResponse]] =
+    when(TestResetEnrolmentsController.ggStubsConnector.resetEnrolments()(Matchers.any[HeaderCarrier]()))
+    .thenReturn(Future.successful(response))
+
+  def mockAuthenticatorResponse(response: HttpResponse): OngoingStubbing[Future[HttpResponse]] =
+    when(TestResetEnrolmentsController.authenticatorConnector.refreshProfile()(Matchers.any[HeaderCarrier]()))
+      .thenReturn(Future.successful(response))
+
+  "ResetEnrolmentsController" should {
+    "use the correct GG stubs connector" in {
+      ResetEnrolmentsController.ggStubsConnector shouldBe GgStubsConnector
+    }
+    "use the correct Authenticator connector" in {
+      ResetEnrolmentsController.authenticatorConnector shouldBe AuthenticatorConnector
+    }
+  }
+
+  "Calling ResetEnrolmentsController.resetEnrolments" when {
+
+    "An OK response is returned from GG Stubs and an OK response is returned from Authenticator" should {
+
+      "Return status OK (200)" in {
+        mockGgStubsResponse(HttpResponse(OK))
+        mockAuthenticatorResponse(HttpResponse(OK))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        status(await(result)) shouldBe OK
+      }
+
+      "return a message saying 'Successfully Reset Enrolments'" in {
+        mockGgStubsResponse(HttpResponse(OK))
+        mockAuthenticatorResponse(HttpResponse(OK))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        bodyOf(await(result)) shouldBe "Successfully Reset Enrolments"
+      }
+    }
+
+    "An OK response is returned from GG Stubs and a response other than OK is returned from Authenticator" should {
+
+      "Return status OK (200)" in {
+        mockGgStubsResponse(HttpResponse(OK))
+        mockAuthenticatorResponse(HttpResponse(BAD_REQUEST))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        status(await(result)) shouldBe OK
+      }
+
+      "return a message saying 'Successfully Reset Enrolments'" in {
+        mockGgStubsResponse(HttpResponse(OK))
+        mockAuthenticatorResponse(HttpResponse(OK))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        bodyOf(await(result)) shouldBe "Successfully Reset Enrolments"
+      }
+    }
+
+    "A response other than OK is returned from GG Stubs and Authenticator" should {
+
+      "Return status BAD_REQUEST (400)" in {
+        mockGgStubsResponse(HttpResponse(BAD_REQUEST))
+        mockAuthenticatorResponse(HttpResponse(BAD_REQUEST))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        status(await(result)) shouldBe BAD_REQUEST
+      }
+
+      "return a message saying 'Successfully Reset Enrolments'" in {
+        mockGgStubsResponse(HttpResponse(BAD_REQUEST))
+        mockAuthenticatorResponse(HttpResponse(BAD_REQUEST))
+        val result = TestResetEnrolmentsController.resetEnrolments(fakeRequest)
+        bodyOf(await(result)) shouldBe "Failed to Reset Enrolments"
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Merge with <a href="https://github.tools.tax.service.gov.uk/HMRC/service-manager-config/pull/1072">TAVC-1554</a> (service-manager-config to overwrite application.router with the testOnly router)